### PR TITLE
remove jshint legacy option

### DIFF
--- a/app/templates/jshintrc
+++ b/app/templates/jshintrc
@@ -16,6 +16,5 @@
     "unused": true,
     "strict": true,
     "trailing": true,
-    "smarttabs": true,
-    "white": true
+    "smarttabs": true
 }


### PR DESCRIPTION
"white" is a legacy option. 

http://www.jshint.com/docs/options/#white
